### PR TITLE
Added env variables resolving to DoctrineExtension

### DIFF
--- a/DependencyInjection/DoctrineExtension.php
+++ b/DependencyInjection/DoctrineExtension.php
@@ -59,6 +59,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
+        if (method_exists($container, 'resolveEnvPlaceholders')) {
+            $config = $container->resolveEnvPlaceholders($config, true);
+        }
+        
         $this->adapter->loadServicesConfiguration($container);
 
         if (!empty($config['dbal'])) {


### PR DESCRIPTION
Currently I have no way to work with doctrine config that depends on environmental variables as mergeExtensionConfigurationPass is registered before ResolveEnvPlaceholdersPass. This commit allows to work with doctrine config like this:

doctrine:
    orm:
        metadata_cache_driver:
            type: "%env(DOCTRINE_METADATA_CACHE_TYPE)%"
            host: "%env(DOCTRINE_METADATA_CACHE_HOST)%"
            port: "%env(DOCTRINE_METADATA_CACHE_PORT)%"
        query_cache_driver:
            type: "%env(DOCTRINE_QUERY_CACHE_TYPE)%"
            host: "%env(DOCTRINE_QUERY_CACHE_HOST)%"
            port: "%env(DOCTRINE_QUERY_CACHE_PORT)%"
        result_cache_driver:
            type: "%env(DOCTRINE_RESULT_CACHE_TYPE)%"
            host: "%env(DOCTRINE_RESULT_CACHE_HOST)%"
            port: "%env(DOCTRINE_RESULT_CACHE_PORT)%"